### PR TITLE
Update Docker image for deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,11 +7,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
-    container:
-        image: albertkun/mkdocs-teaching-materials
     steps:
        - uses: actions/checkout@v2
-       - run: mkdocs gh-deploy --force
+       - name: Deploy
+         uses: docker://ghcr.io/peaceiris/mkdocs-material:latest
+         with:
+           github_token: ${{ secrets.GH_TOKEN }}
+           build: 'mkdocs gh-deploy --force'
 env:
-  GH_TOKEN: ${{secrets.GH_TOKEN}}          
   ASIA_191_PASS: ${{secrets.ASIA_191_PASS}}


### PR DESCRIPTION
This pull request updates the `mkdocs.yml` file to use the correct Docker image for deployment. The previous image was replaced with `ghcr.io/peaceiris/mkdocs-material:latest`. This change ensures that the deployment process uses the latest version of the Docker image.